### PR TITLE
Fix already cached image PUT requests

### DIFF
--- a/api.py
+++ b/api.py
@@ -352,6 +352,7 @@ if _server is not None:
         try:
             id = request.match_info.get("id", "")
             if id in image_cache:
+                await request.release()  # Consume and discard the data to avoid connection abort
                 return web.json_response(dict(status="cached"), status=200)
 
             content_type = request.headers.get("Content-Type", "application/octet-stream")
@@ -364,15 +365,12 @@ if _server is not None:
         except Exception as e:
             return web.json_response(dict(error=str(e)), status=500)
 
-    async def _put_image_expect_handler(request: web.Request) -> None:
-        # Only send "100 Continue" if the image isn't already cached.
-        # This allows clients to avoid sending the image data.
-        expect = request.headers.get("Expect", "")
-        if expect.lower() == "100-continue":
-            id = request.match_info.get("id", "")
-            if id not in image_cache:
-                await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
-                request.writer.output_size = 0
+    async def _put_image_expect_handler(request: web.Request):
+        if request.match_info.get("id", "") in image_cache:
+            # Skip "100 Continue" since we don't need the data, return 200 immediately.
+            return web.json_response(dict(status="cached"), status=200)
+        # otherwise run default aiohttp handler
+        return None
 
     _server.app.router.add_route(
         "PUT", "/api/etn/image/{id}", put_image, expect_handler=_put_image_expect_handler

--- a/api.py
+++ b/api.py
@@ -348,7 +348,6 @@ if _server is not None:
         except Exception as e:
             return web.json_response(dict(error=str(e)), status=500)
 
-    @_server.routes.put("/api/etn/image/{id}")
     async def put_image(request: web.Request):
         try:
             id = request.match_info.get("id", "")
@@ -364,6 +363,20 @@ if _server is not None:
             return web.json_response(dict(status="success"), status=201)
         except Exception as e:
             return web.json_response(dict(error=str(e)), status=500)
+
+    async def _put_image_expect_handler(request: web.Request) -> None:
+        # Only send "100 Continue" if the image isn't already cached.
+        # This allows clients to avoid sending the image data.
+        expect = request.headers.get("Expect", "")
+        if expect.lower() == "100-continue":
+            id = request.match_info.get("id", "")
+            if id not in image_cache:
+                await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+                request.writer.output_size = 0
+
+    _server.app.router.add_route(
+        "PUT", "/api/etn/image/{id}", put_image, expect_handler=_put_image_expect_handler
+    )
 
     @_server.routes.put("/api/etn/upload/{folder_name}/{filename}")
     async def upload(request: web.Request):


### PR DESCRIPTION
_LLM output:_

### What changed

 A new _put_image_expect_handler coroutine is defined and wired into the route via
 @_server.routes.put("/api/etn/image/{id}", expect_handler=_put_image_expect_handler). The route handler
 body is otherwise unchanged.

 ────────────────────────────────────────────────────────────────────────────────

 ### Why the old code broke

 aiohttp intercepts any request that carries an Expect header and calls the route's expect handler before
  the actual route handler runs (web_app.py line 543-544). The built-in _default_expect_handler
 unconditionally sends HTTP/1.1 100 Continue\r\n\r\n the moment it is called. The client interprets that
 as permission to stream the full body. By the time put_image runs and discovers the image is already
 cached, the body is already in flight — returning a response without consuming it causes a TCP-level
 connection abort on the client side.

 ────────────────────────────────────────────────────────────────────────────────

 ### How the fix works

 The custom _put_image_expect_handler:

 1. Checks Expect: 100-continue — only acts on the one token it understands (mirrors the default
 handler's contract).
 2. Looks up the image ID in the cache — request.match_info is fully populated at expect-handler time
 because routing already resolved before aiohttp calls the expect handler.
 3. Sends 100 Continue only when the image is not cached — if it's cached, the handler returns without
 writing anything. The client then receives the final 200 response instead of an interim 100, and per RFC
 9110 §10.1.1 must not send the body. No body → no abort.
 4. Resets request.writer.output_size = 0 after writing 100 Continue — this is what the aiohttp default
 handler also does so that the eventual response's byte-count accounting starts clean.